### PR TITLE
Feature: filter statewise list by case type like: death, recovered etc

### DIFF
--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -21,7 +21,9 @@ const papaparseOptions = {
   skipEmptyLines: true,
   transformHeader: header => header.toLowerCase().replace(/\W/g, "_")
 };
-
+//temp1.data.regional.filter(d => !!d.discharged).map(d => ({state: d.loc, discharged: d.discharged}))
+//temp1.data.regional.filter(d => !!(d.confirmedCasesIndian + d.confirmedCasesForeign)).map(d=> ({state: d.loc, indian: d.confirmedCasesIndian, foreign: d.confirmedCasesForeign}))
+//temp1.data.regional.filter(d => !!d.deaths).map(d=> ({state: d.loc, dead: d.deaths}))
 const PopupLineItem = ({ type, count, legend }) => {
   return (
     <>
@@ -142,7 +144,9 @@ export default function MapContainer(props) {
               )
             )
           );
+
           setCountrySummary(result.data.summary);
+          // settemp1.data.regional.filter(d => !!d.discharged).map(d => ({ state: d.loc, discharged: d.discharged }))
         },
         error => {
           console.log("Error Response");

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -21,9 +21,7 @@ const papaparseOptions = {
   skipEmptyLines: true,
   transformHeader: header => header.toLowerCase().replace(/\W/g, "_")
 };
-//temp1.data.regional.filter(d => !!d.discharged).map(d => ({state: d.loc, discharged: d.discharged}))
-//temp1.data.regional.filter(d => !!(d.confirmedCasesIndian + d.confirmedCasesForeign)).map(d=> ({state: d.loc, indian: d.confirmedCasesIndian, foreign: d.confirmedCasesForeign}))
-//temp1.data.regional.filter(d => !!d.deaths).map(d=> ({state: d.loc, dead: d.deaths}))
+
 const PopupLineItem = ({ type, count, legend }) => {
   return (
     <>
@@ -146,7 +144,6 @@ export default function MapContainer(props) {
           );
 
           setCountrySummary(result.data.summary);
-          // settemp1.data.regional.filter(d => !!d.discharged).map(d => ({ state: d.loc, discharged: d.discharged }))
         },
         error => {
           console.log("Error Response");

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -30,7 +30,7 @@ const PopupLineItem = ({ type, count, legend }) => {
       <div className={cx(["popup-legend", "legend-" + legend])}></div>
       <div className={cx("count-type")}>{type}</div>
       <div className={cx("counts")}>
-        {count.toLocaleString(navigator.language, { maximumFractionDigits: 2 })}
+        {count !== undefined && count !== null ? count.toLocaleString(navigator.language, { maximumFractionDigits: 2 }) : ''}
       </div>
     </>
   );

--- a/src/components/stateWiseList/DetailedTile.js
+++ b/src/components/stateWiseList/DetailedTile.js
@@ -2,7 +2,7 @@ import React from "react";
 import classNames from "classnames/bind";
 const cx = classNames.bind(require("./detailedTile.module.css"));
 export default function DetailedTile(props) {
-  const { locationData = {} } = props;
+  const { locationData = {}, handleCaseTypeClick } = props;
   return (
     <>
       <section>
@@ -10,14 +10,14 @@ export default function DetailedTile(props) {
           <div className={cx("title")} title="Total Confirmed Cases">
             Total Confirmed Cases
           </div>
-          <div className={cx("confirmed")}>{locationData.total || 0}</div>
+          <div className={cx("confirmed")} onClick={() => handleCaseTypeClick("all")}>{locationData.total || 0}</div>
           <div className={cx("legend")}>
             <div
               className={cx("legend-icon")}
               style={{ background: "rgb(244, 195, 99)" }}
             ></div>
             <div className={cx("description")}>Active cases</div>
-            <div className={`${cx("total")} ${cx("active-case")} `}>
+            <div className={`${cx(["total", "active-case"])} `} onClick={() => handleCaseTypeClick('active')}>
               {locationData.total - locationData.discharged || 0}
             </div>
             <div
@@ -25,7 +25,7 @@ export default function DetailedTile(props) {
               style={{ background: "rgb(96, 187, 105)" }}
             ></div>
             <div className={cx("description")}>Recovered cases</div>
-            <div className={`${cx("total")} ${cx("recovered-case")}`}>
+            <div className={`${cx(["total", "recovered-case"])}`} onClick={() => handleCaseTypeClick('recovered')}>
               {locationData.discharged || 0}
             </div>
             <div
@@ -33,7 +33,7 @@ export default function DetailedTile(props) {
               style={{ background: "rgb(118, 118, 118)" }}
             ></div>
             <div className={cx("description")}>Deaths</div>
-            <div className={`${cx("total")} ${cx("death-case")}`}>
+            <div className={`${cx(["total", "death-case"])}`} onClick={() => handleCaseTypeClick('death')}>
               {locationData.deaths || 0}
             </div>
           </div>

--- a/src/components/stateWiseList/DetailedTile.js
+++ b/src/components/stateWiseList/DetailedTile.js
@@ -2,7 +2,7 @@ import React from "react";
 import classNames from "classnames/bind";
 const cx = classNames.bind(require("./detailedTile.module.css"));
 export default function DetailedTile(props) {
-  const { locationData = {}, handleCaseTypeClick } = props;
+  const { locationData = {}, handleCaseTypeClick = ()=>{} } = props;
   return (
     <>
       <section>

--- a/src/components/stateWiseList/IndiaData.js
+++ b/src/components/stateWiseList/IndiaData.js
@@ -53,7 +53,7 @@ export default function IndiaData(props) {
       },
       active: {
         tileList: indiaData.regional.filter(d => !!(d.confirmedCasesIndian + d.confirmedCasesForeign))
-                                    .map(d => ({state: d.loc, count: d.confirmedCasesIndian + d.confirmedCasesForeign, stateData: d})),
+                                    .map(d => ({state: d.loc, count: (d.confirmedCasesIndian + d.confirmedCasesForeign) - d.discharged, stateData: d})),
         total: indiaData.summary.total - indiaData.summary.discharged,
         styles: ["case-total", "active-case"] 
       },
@@ -64,6 +64,7 @@ export default function IndiaData(props) {
 
       }
     };
+    console.log(statsByType);
     setIndianStatsByType(statsByType);
   }, [indiaData])
 

--- a/src/components/stateWiseList/IndiaData.js
+++ b/src/components/stateWiseList/IndiaData.js
@@ -26,14 +26,13 @@ export default function IndiaData(props) {
     props.onTesteCenterToggle(!viewTestCenters);
   };
 
-  const statByType = { tileList: [], total: 0, styles: [] };
+  const statByType = { tileList: [], total: 0, styleClasses: [] };
   const initialStatsByType = {death: statByType, active: statByType, recovered: statByType, all: statByType}
   const [indianStatsByType, setIndianStatsByType] = useState(initialStatsByType);
   const [selectedType, setSelectedType] = useState('all');
 
   // creating categorized state/count/fullData lookup for filtering StateWiseList by each case
   useEffect(() => {
-    console.log('indiaData', indiaData)
     if (!indiaData || !indiaData.regional) {
       return;
     }
@@ -42,29 +41,28 @@ export default function IndiaData(props) {
         tileList: indiaData.regional.filter(d => !!d.deaths)
                                     .map(d => ({state: d.loc, count: d.deaths, stateData: d})),
         total: indiaData.summary.deaths,
-        styles: ["case-total", "death-case"] 
+        styleClasses: ["case-total", "death-case"] 
       },
       recovered: {
         tileList: indiaData.regional
                     .filter(d => !!d.discharged)
                     .map(d => ({state: d.loc, count: d.discharged, stateData: d})),
         total: indiaData.summary.discharged,
-        styles: ["case-total", "recovered-case"] 
+        styleClasses: ["case-total", "recovered-case"] 
       },
       active: {
         tileList: indiaData.regional.filter(d => !!(d.confirmedCasesIndian + d.confirmedCasesForeign))
                                     .map(d => ({state: d.loc, count: (d.confirmedCasesIndian + d.confirmedCasesForeign) - d.discharged, stateData: d})),
         total: indiaData.summary.total - indiaData.summary.discharged,
-        styles: ["case-total", "active-case"] 
+        styleClasses: ["case-total", "active-case"] 
       },
       all: {
         tileList: indiaData.regional.map(d => ({ state: d.loc, count: d.confirmedCasesIndian + d.confirmedCasesForeign, stateData: d})),
         total: indiaData.summary.total,
-        styles: ["total-confirmed-cases"] 
+        styleClasses: ["total-confirmed-cases"] 
 
       }
     };
-    console.log(statsByType);
     setIndianStatsByType(statsByType);
   }, [indiaData])
 
@@ -90,7 +88,7 @@ export default function IndiaData(props) {
             <List component="nav">
               <ListItem button>
                 <ListItemText primary="India" />
-                <ListItemSecondaryAction className={cx(indianStatsByType[selectedType].styles)}>
+                <ListItemSecondaryAction className={cx(indianStatsByType[selectedType].styleClasses)}>
                   {indianStatsByType[selectedType].total}{" "}
                 </ListItemSecondaryAction>
               </ListItem>

--- a/src/components/stateWiseList/StatWiseList.js
+++ b/src/components/stateWiseList/StatWiseList.js
@@ -26,15 +26,14 @@ export default function StateWiseList(props) {
               return (
                 <ListItem
                   button
-                  key={stateData.loc}
+                  key={stateData.state}
                   className={cx("item-list")}
-                  onClick={event => handleListItemClick(stateData, i)}
+                  onClick={event => handleListItemClick(stateData.stateData, i)}
                   selected={selectedIndex === i}
                 >
-                  <ListItemText key={stateData.loc} primary={stateData.loc} />
+                  <ListItemText key={stateData.state} primary={stateData.state} />
                   <ListItemSecondaryAction>
-                    {stateData.confirmedCasesIndian +
-                      stateData.confirmedCasesForeign}
+                    {stateData.count}
                   </ListItemSecondaryAction>
                 </ListItem>
               );

--- a/src/components/stateWiseList/detailedTile.module.css
+++ b/src/components/stateWiseList/detailedTile.module.css
@@ -19,6 +19,7 @@
   color: #de3700;
   font-weight: bold;
   line-height: 40px;
+  cursor: pointer;
 }
 .legend {
   display: grid;

--- a/src/components/stateWiseList/detailedTile.module.css
+++ b/src/components/stateWiseList/detailedTile.module.css
@@ -34,26 +34,19 @@
   height: 8px;
 }
 .total {
-  color: #767676;
+  color: #fff;
   text-align: right;
+  padding: 0 10px;
+  border-radius: 4px;
+  cursor:pointer;
 }
 
 .active-case {
-  padding: 0 10px;
   background-color: rgb(244, 195, 99);
-  color: #fff;
-  border-radius: 4px;
 }
-
 .recovered-case {
-  padding: 0 10px;
   background-color: green;
-  color: #fff;
-  border-radius: 4px;
 }
 .death-case {
-  padding: 0 10px;
   background-color: red;
-  color: #fff;
-  border-radius: 4px;
 }

--- a/src/components/stateWiseList/stateWiseList.module.css
+++ b/src/components/stateWiseList/stateWiseList.module.css
@@ -14,3 +14,28 @@
 .state-list li:not(:last-child) {
   margin-bottom: 12px;
 }
+
+.case-total {
+  color: #fff;
+  text-align: right;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  min-width: 49px;
+}
+.total-confirmed-cases {
+    color: #de3700;
+    font-weight: bold;
+    line-height: 40px;
+    text-align: right;
+    padding-right: 10px;
+}
+.active-case {
+  background-color: rgb(244, 195, 99);
+}
+.recovered-case {
+  background-color: green;
+}
+.death-case {
+  background-color: red;
+}

--- a/src/components/stateWiseList/stateWiseList.module.css
+++ b/src/components/stateWiseList/stateWiseList.module.css
@@ -18,6 +18,7 @@
 .case-total {
   color: #fff;
   text-align: right;
+  font-weight: bold;
   padding: 3px 10px;
   border-radius: 4px;
   cursor: pointer;


### PR DESCRIPTION
We didn't have a quick way to view the list of states with death reports or recovery reports alone, so I think a filter like this without changing much of UI/UX flow will help for that. Please check and let me know the suggestions.

Clicking on counts in the summary section below `show test centers` toggle will filter the state-wise list by death/recovered/active/all based on selection:


![active](https://user-images.githubusercontent.com/7909507/77468283-5a901180-6e33-11ea-9576-88a7b65cd4d3.png)
![dead](https://user-images.githubusercontent.com/7909507/77468494-a347ca80-6e33-11ea-87e4-9012424f4354.png)
